### PR TITLE
Add package.json engines search

### DIFF
--- a/bin/grcs.js
+++ b/bin/grcs.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-const contentsCommand = require('../src/commands/contents');
-
 require('yargs')
-  .command(contentsCommand)
+  .commandDir('../src/commands')
   .argv;

--- a/lib/get-contents.js
+++ b/lib/get-contents.js
@@ -17,8 +17,8 @@ const getContents = ({ path, githubToken }) => {
             })
 
             // deal with case where path leads to a directory rather than a file
-            if (repoData.data.type === 'dir') {
-                throw new Error(`Incorrect value provided for <file>; the provided value '${argv.file}' is for a directory`)
+            if (repoData.data.path !== path) {
+                throw new Error(`Incorrect value provided for <file>; '${path}' is not a file path`)
             } else {
                 const decodedContent = Buffer.from(repoData.data.content, 'base64').toString('utf8');
 
@@ -26,9 +26,9 @@ const getContents = ({ path, githubToken }) => {
             }
         } catch (error) {
             if (error.status === 404) {
-                console.error(`404 ERROR: file '${argv.file}' not found in '${repository}'`)
+                throw new Error(`404 ERROR: file '${path}' not found in '${repository}'`);
             } else {
-                console.error('error', error);
+                throw error;
             }
         }
     };

--- a/lib/get-contents.js
+++ b/lib/get-contents.js
@@ -1,0 +1,37 @@
+const Octokit = require('@octokit/rest');
+
+const getContents = ({ path, githubToken }) => {
+    const octokit = new Octokit({
+        auth: `token ${githubToken}`
+    });
+
+    return async (repository) => {
+        const owner = repository.split('/')[0];
+        const repo = repository.split('/')[1];
+
+        try {
+            const repoData = await octokit.repos.getContents({
+                owner,
+                repo,
+                path
+            })
+
+            // deal with case where path leads to a directory rather than a file
+            if (repoData.data.type === 'dir') {
+                throw new Error(`Incorrect value provided for <file>; the provided value '${argv.file}' is for a directory`)
+            } else {
+                const decodedContent = Buffer.from(repoData.data.content, 'base64').toString('utf8');
+
+                return decodedContent;
+            }
+        } catch (error) {
+            if (error.status === 404) {
+                console.error(`404 ERROR: file '${argv.file}' not found in '${repository}'`)
+            } else {
+                console.error('error', error);
+            }
+        }
+    };
+};
+
+module.exports = getContents;

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+const getContents = require('../../lib/get-contents');
+
+exports.command = 'package <search>';
+exports.desc = 'search for a string within the `package.json` file';
+
+exports.handler = function (argv) {
+    const { token, search } = argv;
+    const repositories = fs.readFileSync('/dev/stdin').toString().split("\n");
+    const path = 'package.json';
+
+    const getPackageJson = getContents({
+        githubToken: token,
+        path
+    });
+    const allRepos = repositories.map(
+        repository => getPackageJson(repository)
+            .then((contents) => {
+                if (contents.includes(search)){
+                    console.log(repository);
+                }
+            })
+    );
+
+    return Promise.all(allRepos);
+};

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -21,6 +21,9 @@ exports.handler = function (argv) {
                     console.log(repository);
                 }
             })
+            .catch(error => {
+                console.error(error);
+            })
     );
 
     return Promise.all(allRepos);

--- a/src/commands/package_engines.js
+++ b/src/commands/package_engines.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+
+const getContents = require('../../lib/get-contents');
+
+exports.command = 'package:engines [search]';
+exports.desc = 'search for a string within the `package.json` engines field';
+
+const processJson = (content) => {  
+    return JSON.parse(content);
+};
+
+exports.handler = function (argv) {
+    const { token, search } = argv;
+    const repositories = fs.readFileSync('/dev/stdin').toString().split("\n");
+    const path = 'package.json';
+
+    const getPackageJson = getContents({
+        githubToken: token,
+        path
+    });
+    const allRepos = repositories.map(
+        repository => getPackageJson(repository)
+            .then((processJson))
+            .catch(() => {
+                console.error(`JSON PARSE ERROR: ${path} parse error in '${repository}'`)
+            })
+            .then((json = {}) => {
+                const { engines } = json;
+                if (engines) {
+                    const enginesOutput = Object.keys(engines).reduce((prevEngineName, engineName, curIndex) => {
+                        const prev = !!curIndex ? `${prevEngineName}@${engines[prevEngineName]}\t` : '';
+                        return  `${prev}${engineName}@${engines[engineName]}`
+                    }, '');
+                    console.log(`${repository}\t${enginesOutput}`);
+                } else {
+                    console.error(`NOT FOUND: engines field not found in '${path}' in '${repository}'`)
+                }
+                
+            })
+    );
+
+    return Promise.all(allRepos);
+};

--- a/src/commands/package_engines.js
+++ b/src/commands/package_engines.js
@@ -13,14 +13,9 @@ const engineVersionDisplay = ({ name, engines }) => `${name}@${engines[name]}`;
 // Report all engines in a tab separated format
 // eg, "node@8.13.0  npm@6.8.0"
 const enginesReport = engines => {
-    return Object.keys(engines).reduce((prev, engineName, curIndex) => {
-        const curEngineVersion = engineVersionDisplay({ name: engineName, engines });
-
-        const isFirst = !curIndex;
-        return isFirst
-            ? curEngineVersion
-            : `${prev}\t${curEngineVersion}`;
-    }, '');
+    return Object.keys(engines)
+        .map(name => `${name}@${engines[name]}`)
+        .join("\t");
 };
 
 exports.handler = function (argv = {}) {

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -33,7 +33,7 @@ describe('contents command handler', () => {
         expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
     });
 
-    test.only('when `contents` command is used with a <file> path that leads to a directory rather than a file, the relevant error is logged', async () => {
+    test('when `contents` command is used with a <file> path that leads to a directory rather than a file, the relevant error is logged', async () => {
         nockScope.get(`/${repo}/contents/server`)
             .reply(200, [
                 { path: 'app.js' },

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -1,0 +1,61 @@
+const nock = require('nock');
+
+const createStandardInput = require('../helpers/create-standard-input');
+const { base64EncodeObj } = require('../helpers/base64');
+const packageCommand = require('../../src/commands/package');
+const repo = 'Financial-Times/next-front-page';
+
+describe('package command handler', () => {
+    let standardInput;
+    const packageHandler = packageCommand.handler;
+
+    beforeEach(() => {
+        standardInput = createStandardInput(repo);
+        nockScope = nock('https://api.github.com/repos');
+        jest.spyOn(console, 'error').mockImplementation().mockName('console.error');
+        jest.spyOn(console, 'log').mockImplementation().mockName('console.log');
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+        jest.resetAllMocks();
+        standardInput.teardown();
+    });
+
+    test('repository not found', async () => {
+        const invalidRepo = 'Financial-Times/invalid';
+        standardInput = createStandardInput(invalidRepo);
+        nockScope.get(`/${invalidRepo}/contents/package.json`)
+            .reply(404, {
+                message: 'Not Found'
+            });
+        await packageHandler({ search: 'something' });
+        expect(console.error.mock.calls[0][0].message).toMatch('404 ERROR');
+    });
+
+    test('found <search> value logs repository', async () => {
+        nockScope.get(`/${repo}/contents/package.json`)
+            .reply(200, {
+                type: 'file',
+                content: base64EncodeObj({
+                    name: 'next-front-page'
+                }),
+                path: 'package.json'
+            });
+        await packageHandler({ search: 'name' });
+        expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
+    });
+
+    test('<search> value not found, does not log', async () => {
+        nockScope.get(`/${repo}/contents/package.json`)
+            .reply(200, {
+                type: 'file',
+                content: base64EncodeObj({
+                    name: 'next-front-page'
+                }),
+                path: 'package.json'
+            });
+        await packageHandler({ search: 'something-else' });
+        expect(console.log).not.toBeCalled();
+    });
+});

--- a/test/commands/package_engines.test.js
+++ b/test/commands/package_engines.test.js
@@ -1,0 +1,82 @@
+const nock = require('nock');
+
+const createStandardInput = require('../helpers/create-standard-input');
+const { base64EncodeObj } = require('../helpers/base64');
+const packageEnginesCommand = require('../../src/commands/package_engines');
+const repo = 'Financial-Times/next-front-page';
+
+describe('package:engines command handler', () => {
+    let standardInput;
+    const packageEnginesHandler = packageEnginesCommand.handler;
+
+    beforeEach(() => {
+        standardInput = createStandardInput(repo);
+        nockScope = nock('https://api.github.com/repos');
+        jest.spyOn(console, 'error').mockImplementation().mockName('console.error');
+        jest.spyOn(console, 'log').mockImplementation().mockName('console.log');
+    });
+
+    afterEach(() => {
+        nock.cleanAll();
+        jest.resetAllMocks();
+        standardInput.teardown();
+    });
+
+    test('repository not found', async () => {
+        const invalidRepo = 'Financial-Times/invalid';
+        standardInput = createStandardInput(invalidRepo);
+        nockScope.get(`/${invalidRepo}/contents/package.json`)
+            .reply(404, {
+                message: 'Not Found'
+            });
+        await packageEnginesHandler();
+        expect(console.error.mock.calls[0][0].message).toMatch('404 ERROR');
+    });
+
+    test('found engines in package.json logs repository', async () => {
+        nockScope.get(`/${repo}/contents/package.json`)
+            .reply(200, {
+                type: 'file',
+                content: base64EncodeObj({
+                    engines: {
+                        node: '~10.15.0'
+                    }
+                }),
+                path: 'package.json'
+            });
+        await packageEnginesHandler();
+
+        expect(console.log.mock.calls[0][0]).toContain('Financial-Times/next-front-page');
+        expect(console.log.mock.calls[0][0]).toContain('~10.15.0');
+    });
+
+    test('found multiple engines in package.json logs repository', async () => {
+        nockScope.get(`/${repo}/contents/package.json`)
+            .reply(200, {
+                type: 'file',
+                content: base64EncodeObj({
+                    engines: {
+                        node: '~10.15.0',
+                        npm: '6.8.0'
+                    }
+                }),
+                path: 'package.json'
+            });
+        await packageEnginesHandler();
+
+        expect(console.log.mock.calls[0][0]).toContain('Financial-Times/next-front-page');
+        expect(console.log.mock.calls[0][0]).toContain('node@~10.15.0');
+        expect(console.log.mock.calls[0][0]).toContain('npm@6.8.0');
+    });
+
+    test('engines value not found in package.json, does not log', async () => {
+        nockScope.get(`/${repo}/contents/package.json`)
+            .reply(200, {
+                type: 'file',
+                content: base64EncodeObj({}),
+                path: 'package.json'
+            });
+        await packageEnginesHandler();
+        expect(console.log).not.toBeCalled();
+    });
+});

--- a/test/helpers/base64.js
+++ b/test/helpers/base64.js
@@ -1,0 +1,5 @@
+const base64EncodeObj = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64');
+
+module.exports = {
+    base64EncodeObj
+};

--- a/test/helpers/create-standard-input.js
+++ b/test/helpers/create-standard-input.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+
+jest.mock('fs');
+
+const createStandardInput = (data) => {
+    const mockReadFileSync = fs.readFileSync.mockImplementation(() => data);
+
+    return {
+        teardown: () => {
+            mockReadFileSync.mockReset();
+        }
+    }
+}
+
+module.exports = createStandardInput;
+


### PR DESCRIPTION
Implements https://github.com/Financial-Times/github-repositories-contents-search/issues/3

---

To run

```
$ cat tmp/repositories.txt | ./bin/grcs.js --token $GITHUB_PERSONAL_ACCESS_TOKEN package bugs
Financial-Times/next-product
Financial-Times/n-membership-sdk
Financial-Times/next-signup
```

```
$ cat tmp/repositories.txt | ./bin/grcs.js --token $GITHUB_PERSONAL_ACCESS_TOKEN package:engines
Financial-Times/next-signup	node@8.13.0
Financial-Times/next-front-page	node@8.13.0
Financial-Times/next-search-page	node@8.13.0
Financial-Times/n-membership-sdk	node@^8.9.3
Financial-Times/next-product	node@8.13.0
```

TODO:

* [x] Tests