### PR TITLE
Allow contents search to be empty

### DIFF
--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -2,9 +2,10 @@ const fs = require('fs');
 
 const getContents = require('../../lib/get-contents');
 
-exports.command = 'contents [--token=<token>] <file> <search>';
+exports.command = 'contents [--token=<token>] <file> [search]';
 
-exports.describe = 'search for a string within the repositories file';
+exports.describe =
+	'Search for a string within the repositories file. Returns whether the file exists if `search` is empty.';
 
 exports.builder = yargs => {
 	// TODO: this better
@@ -27,7 +28,10 @@ exports.handler = argv => {
 	const allRepos = repositories.map(repository =>
 		getPathContents(repository)
 			.then(contents => {
-				if (contents.includes(search)) {
+				const noSearch = !search;
+				const containsSearchItem = contents.includes(search);
+
+				if (noSearch || containsSearchItem) {
 					console.log(repository);
 				}
 			})

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -44,6 +44,24 @@ describe('contents command handler', () => {
 		);
 	});
 
+	test('empty `contents` search, logs existence of file', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
+			type: 'file',
+			content: base64Encode('web: n-cluster server/init.js'),
+			path: 'Procfile'
+		});
+		await contentsHandler({ file: 'Procfile' });
+		expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
+	});
+
+	test('empty `contents` search, does not log if file does not exist', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
+		await contentsHandler({ file: 'Procfile' });
+		expect(console.log).not.toBeCalledWith(
+			'Financial-Times/next-front-page'
+		);
+	});
+
 	test('<search> value not found, does not log', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
 			type: 'file',

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -1,6 +1,7 @@
 const nock = require('nock');
 
 const createStandardInput = require('../helpers/create-standard-input');
+const { base64Encode } = require('../helpers/base64');
 const contentsCommand = require('../../src/commands/contents');
 const repo = 'Financial-Times/next-front-page';
 
@@ -26,7 +27,7 @@ describe('contents command handler', () => {
 	test('when contents handler is called with valid <file> and <search> values, a list of repositories are logged', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
 			type: 'file',
-			content: 'd2ViOiBuLWNsdXN0ZXIgc2VydmVyL2luaXQuanM=', //base64 encoding of 'web: n-cluster server/init.js'
+			content: base64Encode('web: n-cluster server/init.js'),
 			path: 'Procfile'
 		});
 		await contentsHandler({ file: 'Procfile', search: 'web' });
@@ -46,7 +47,7 @@ describe('contents command handler', () => {
 	test('<search> value not found, does not log', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
 			type: 'file',
-			content: 'd2ViOiBuLWNsdXN0ZXIgc2VydmVyL2luaXQuanM=', //base64 encoding of 'web: n-cluster server/init.js'
+			content: base64Encode('web: n-cluster server/init.js'),
 			path: 'Procfile'
 		});
 		await contentsHandler({

--- a/test/helpers/base64.js
+++ b/test/helpers/base64.js
@@ -1,6 +1,8 @@
-const base64EncodeObj = obj =>
-	Buffer.from(JSON.stringify(obj)).toString('base64');
+const base64Encode = str => Buffer.from(str).toString('base64');
+
+const base64EncodeObj = obj => base64Encode(JSON.stringify(obj));
 
 module.exports = {
+	base64Encode,
 	base64EncodeObj
 };


### PR DESCRIPTION
Also make search argument optional.

Fixes https://github.com/Financial-Times/github-repositories-contents-search/issues/21