### PR TITLE
Print out no match results for contents search

### DIFF
--- a/src/commands/contents.js
+++ b/src/commands/contents.js
@@ -2,14 +2,27 @@ const fs = require('fs');
 
 const getContents = require('../../lib/get-contents');
 
-exports.command = 'contents [--token=<token>] <file> [search]';
+exports.command = 'contents <file> [search]';
 
-exports.describe =
-	'Search for a string within the repositories file. Returns whether the file exists if `search` is empty.';
+exports.describe = 'Search within a repositories file';
 
 exports.builder = yargs => {
-	// TODO: this better
-	return yargs;
+	return yargs
+		.positional('file', {
+			type: 'string',
+			describe: 'File path to search in GitHub contents API'
+		})
+		.positional('search', {
+			type: 'string',
+			describe:
+				'What to search for. If empty, returns whether the file exists or not'
+		})
+		.option('token', {
+			required: true,
+			type: 'string',
+			describe:
+				'GitHub personal access token. Generate one from https://github.com/settings/tokens'
+		});
 };
 
 exports.handler = argv => {
@@ -32,7 +45,11 @@ exports.handler = argv => {
 				const containsSearchItem = contents.includes(search);
 
 				if (noSearch || containsSearchItem) {
-					console.log(repository);
+					return console.log(repository);
+				} else {
+					console.error(
+						`INFO: '${path}' has no match for '${search}' in '${repository}'`
+					);
 				}
 			})
 			.catch(error => {

--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -3,7 +3,21 @@ const fs = require('fs');
 const getContents = require('../../lib/get-contents');
 
 exports.command = 'package <search>';
-exports.desc = 'search for a string within the `package.json` file';
+exports.desc = 'Search within the `package.json` file';
+
+exports.builder = yargs => {
+	return yargs
+		.positional('search', {
+			type: 'string',
+			describe: 'What to search for'
+		})
+		.option('token', {
+			required: true,
+			type: 'string',
+			describe:
+				'GitHub personal access token. Generate one from https://github.com/settings/tokens'
+		});
+};
 
 exports.handler = function(argv) {
 	const { token, search } = argv;

--- a/src/commands/package_engines.js
+++ b/src/commands/package_engines.js
@@ -4,7 +4,21 @@ const { pick, pickBy, merge } = require('lodash');
 const getContents = require('../../lib/get-contents');
 
 exports.command = 'package:engines [search]';
-exports.desc = 'search for a string within the `package.json` engines field';
+exports.desc = 'Search `engines` field inside the `package.json` file';
+
+exports.builder = yargs => {
+	return yargs
+		.positional('search', {
+			type: 'string',
+			describe: 'What to search for. If empty, returns all `engines`'
+		})
+		.option('token', {
+			required: true,
+			type: 'string',
+			describe:
+				'GitHub personal access token. Generate one from https://github.com/settings/tokens'
+		});
+};
 
 const processJson = content => {
 	return JSON.parse(content);

--- a/test/commands/contents.test.js
+++ b/test/commands/contents.test.js
@@ -54,15 +54,27 @@ describe('contents command handler', () => {
 		expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
 	});
 
-	test('empty `contents` search, does not log if file does not exist', async () => {
+	test('logs error if file does not exist', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
-		await contentsHandler({ file: 'Procfile' });
-		expect(console.log).not.toBeCalledWith(
-			'Financial-Times/next-front-page'
+		await contentsHandler({ file: 'Procfile', search: 'something' });
+
+		expect(console.error).toBeCalledWith(expect.stringContaining('ERROR'));
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('Financial-Times/next-front-page')
 		);
 	});
 
-	test('<search> value not found, does not log', async () => {
+	test('logs error if file does not exist (with no search)', async () => {
+		nockScope.get(`/${repo}/contents/Procfile`).reply(404);
+		await contentsHandler({ file: 'Procfile' });
+
+		expect(console.error).toBeCalledWith(expect.stringContaining('ERROR'));
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('Financial-Times/next-front-page')
+		);
+	});
+
+	test('<search> value not found, logs info message in console error', async () => {
 		nockScope.get(`/${repo}/contents/Procfile`).reply(200, {
 			type: 'file',
 			content: base64Encode('web: n-cluster server/init.js'),
@@ -72,6 +84,10 @@ describe('contents command handler', () => {
 			file: 'Procfile',
 			search: 'something-else'
 		});
-		expect(console.log).not.toBeCalled();
+
+		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no match')
+		);
 	});
 });


### PR DESCRIPTION
Also cleaned up how we user yargs builder

Fixes https://github.com/Financial-Times/github-repositories-contents-search/issues/31