### PR TITLE
Show non matched results for `package` and `package:engines` 

### DIFF
--- a/src/commands/package.js
+++ b/src/commands/package.js
@@ -27,6 +27,10 @@ exports.handler = function(argv) {
 			.then(contents => {
 				if (contents.includes(search)) {
 					console.log(repository);
+				} else {
+					console.error(
+						`INFO: '${path}' has no match for '${search}' in '${repository}'`
+					);
 				}
 			})
 			.catch(error => {

--- a/src/commands/package_engines.js
+++ b/src/commands/package_engines.js
@@ -79,6 +79,10 @@ exports.handler = function(argv = {}) {
 				const hasEngines = !!Object.keys(engines).length;
 				if (hasEngines) {
 					console.log(`${repository}\t${enginesOutput}`);
+				} else {
+					console.error(
+						`INFO: '${path}' has no match for '${search}' in '${repository}'`
+					);
 				}
 			})
 			.catch(error => {

--- a/test/commands/package.test.js
+++ b/test/commands/package.test.js
@@ -60,7 +60,7 @@ describe('package command handler', () => {
 		expect(console.log).toBeCalledWith('Financial-Times/next-front-page');
 	});
 
-	test('<search> value not found, does not log', async () => {
+	test('<search> value not found, logs info message in console error', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',
 			content: base64EncodeObj({
@@ -69,7 +69,10 @@ describe('package command handler', () => {
 			path: 'package.json'
 		});
 		await packageHandler({ search: 'something-else' });
-		expect(console.log).not.toBeCalled();
+		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no match')
+		);
 	});
 });
 

--- a/test/commands/package_engines.test.js
+++ b/test/commands/package_engines.test.js
@@ -186,6 +186,19 @@ describe('package:engines command handler', () => {
 		);
 	});
 
+	test('engines search not found in package.json, logs info message in console error', async () => {
+		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
+			type: 'file',
+			content: base64EncodeObj({ engines: {} }),
+			path: 'package.json'
+		});
+		await packageEnginesHandler();
+		expect(console.error).toBeCalledWith(expect.stringContaining(repo));
+		expect(console.error).toBeCalledWith(
+			expect.stringContaining('no match')
+		);
+	});
+
 	test('package.json not valid JSON', async () => {
 		nockScope.get(`/${repo}/contents/package.json`).reply(200, {
 			type: 'file',


### PR DESCRIPTION
* `package`: https://github.com/Financial-Times/github-repositories-contents-search/commit/086a05f9df1fd4334b4cd474bf4f334feef8c6ad
* `package:engines`: https://github.com/Financial-Times/github-repositories-contents-search/commit/7f548c6d7178483eb24c79ea9d025c6492135274

Fixes https://github.com/Financial-Times/github-repositories-contents-search/issues/34 and  https://github.com/Financial-Times/github-repositories-contents-search/issues/44